### PR TITLE
Add Facebook video support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-# Instagram & TikTok Video Downloader
+# Instagram, TikTok & Facebook Video Downloader
 
-A Node.js command-line tool and Telegram bot to download videos from Instagram and TikTok.
+A Node.js command-line tool and Telegram bot to download videos from Instagram, TikTok and Facebook.
 
 ## Features
 
 - Download videos from Instagram (Reels and Posts)
 - Download videos from TikTok
+- Download videos from Facebook
 - Batch download from a text file containing multiple URLs
 - Progress indicator during download
 - Automatic filename generation with platform and ID
-- URL validation for both platforms
+- URL validation for all platforms
 - Error handling for invalid or private content
 - Telegram bot for downloading videos directly in chat
 
@@ -98,7 +99,7 @@ Downloaded videos are saved with the following naming format:
 
 ## Telegram Bot Usage
 
-This tool also includes a Telegram bot that can download Instagram and TikTok videos directly in your chat!
+This tool also includes a Telegram bot that can download Instagram, TikTok and Facebook videos directly in your chat!
 
 ### Setting up the Bot
 
@@ -129,7 +130,7 @@ This tool also includes a Telegram bot that can download Instagram and TikTok vi
 
 1. Start a chat with your bot on Telegram
 2. Send `/start` to see the welcome message
-3. Send any Instagram or TikTok video URL
+3. Send any Instagram, TikTok or Facebook video URL
 4. The bot will download and send you the video
 
 ### Bot Features
@@ -208,11 +209,11 @@ docker build -f Dockerfile.prod -t instagram-reels-bot:prod .
 
 ## Note on Implementation
 
-This tool uses the `btch-downloader` package which provides a reliable way to download content from both Instagram and TikTok. The package handles anti-scraping measures and provides video URLs through a proxy service.
+This tool uses the `btch-downloader` package which provides a reliable way to download content from Instagram, TikTok and Facebook. The package handles anti-scraping measures and provides video URLs through a proxy service.
 
 ## Limitations
 
-- Only works with public content on both platforms
+- Only works with public content on all platforms
 - Platforms may rate-limit requests if too many downloads are attempted
 - Video quality depends on what the platforms provide
 - The tool depends on third-party services which may occasionally be unavailable
@@ -228,4 +229,4 @@ This tool uses the `btch-downloader` package which provides a reliable way to do
 
 ## Disclaimer
 
-This tool is for educational purposes only. Please respect the Terms of Service of Instagram and TikTok, as well as content creators' rights when downloading content.
+This tool is for educational purposes only. Please respect the Terms of Service of Instagram, TikTok and Facebook, as well as content creators' rights when downloading content.

--- a/index.js
+++ b/index.js
@@ -4,13 +4,17 @@ const { program } = require('commander');
 const ora = require('ora').default;
 const fs = require('fs');
 const path = require('path');
-const { downloadVideo, validateInstagramUrl, validateTikTokUrl } = require('./downloader');
+const { downloadVideo, validateInstagramUrl, validateTikTokUrl, validateFacebookUrl } = require('./downloader');
 
 // CLI-specific download wrapper with spinner
 async function downloadWithSpinner(url, outputDir) {
   console.log(`\nProcessing: ${url}`);
   
-  const platform = validateInstagramUrl(url) ? 'Instagram' : 'TikTok';
+  const platform = validateInstagramUrl(url)
+    ? 'Instagram'
+    : validateTikTokUrl(url)
+      ? 'TikTok'
+      : 'Facebook';
   const spinner = ora(`Fetching ${platform} video data...`).start();
   
   try {
@@ -84,9 +88,9 @@ async function batchDownload(filePath, outputDir) {
 // CLI setup
 program
   .name('video-downloader')
-  .description('Download Instagram and TikTok videos')
+  .description('Download Instagram, TikTok and Facebook videos')
   .version('1.1.0')
-  .argument('[url]', 'Instagram or TikTok video URL to download')
+  .argument('[url]', 'Instagram, TikTok or Facebook video URL to download')
   .option('-o, --output <dir>', 'output directory', './downloads')
   .option('-b, --batch <file>', 'batch download from file containing URLs')
   .action(async (url, options) => {
@@ -99,7 +103,7 @@ program
         await downloadWithSpinner(url, options.output);
       } else {
         // No URL provided
-        console.error('Error: Please provide an Instagram or TikTok URL or use --batch option');
+        console.error('Error: Please provide an Instagram, TikTok or Facebook URL or use --batch option');
         program.help();
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- support Facebook videos in CLI, bot and downloader
- update README with Facebook instructions

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870f7a5f9488323af58dc8d488a19af